### PR TITLE
Conditionally log in the BPF program

### DIFF
--- a/src/bpf/vmlinux.h
+++ b/src/bpf/vmlinux.h
@@ -273,3 +273,10 @@ typedef __u32 __be32;
 typedef __u64 __be64;
 
 typedef __u32 __wsum;
+
+typedef _Bool bool;
+
+enum {
+    false = 0,
+    true = 1,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ struct RecordSubcommand {
     duration: Option<u64>,
     #[clap(subcommand)]
     record_type: RecordType,
+    #[clap(long)]
+    verbose_bpf_logging: bool,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -51,7 +53,11 @@ fn main() -> Result<()> {
                 },
                 RecordType::Syscall { name } => RbperfEvent::Syscall(name),
             };
-            let options = RbperfOptions { event };
+            let options = RbperfOptions {
+                event,
+                verbose_bpf_logging: record.verbose_bpf_logging,
+            };
+
             let mut r = Rbperf::new(options);
             r.add_pid(record.pid)?;
 


### PR DESCRIPTION
with the `--verbose-bpf-logging` flag:

```
$ rbperf record --pid `pidof ruby-mri` --verbose-bpf-logging syscall enter_writev
```

Logs can be read from /sys/kernel/debug/tracing/trace_pipe