### PR TITLE
Test helpers to read and write C data

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,8 @@ impl ParseCallbacks for BuildCallbacks {
     fn add_derives(&self, name: &str) -> Vec<String> {
         if name == "RubyVersionOffsets" {
             vec!["Serialize".into(), "Deserialize".into()]
+        } else if name == "RubyStack" {
+            vec!["PartialEq".into(), "Eq".into()]
         } else {
             vec![]
         }

--- a/src/ruby_readers.rs
+++ b/src/ruby_readers.rs
@@ -22,3 +22,64 @@ pub unsafe fn parse_stack(x: &[u8]) -> RubyStack {
 pub unsafe fn parse_frame(x: &[u8]) -> RubyFrame {
     ptr::read_unaligned(x.as_ptr() as *const RubyFrame)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ruby_stack_status_STACK_INCOMPLETE, COMM_MAXLEN, MAX_STACK};
+
+    #[test]
+    fn test_parse_empty_char_buffer() {
+        let buffer: [u8; 20] = [0; 20];
+        assert!(unsafe { str_from_u8_nul(&buffer) }.is_ok());
+        assert_eq!("", unsafe { str_from_u8_nul(&buffer) }.unwrap());
+    }
+
+    #[test]
+    fn test_parse_char_buffer_works() {
+        let mut buffer: [u8; 20] = [0; 20];
+        buffer[0] = 114; // r
+        buffer[1] = 117; // u
+        buffer[2] = 98; // b
+        buffer[3] = 121; // y
+
+        assert!(unsafe { str_from_u8_nul(&buffer) }.is_ok());
+        assert_eq!("ruby", unsafe { str_from_u8_nul(&buffer) }.unwrap());
+    }
+
+    #[test]
+    fn test_parse_malformed_char_buffer_errors() {
+        let mut buffer: [u8; 20] = [0; 20];
+        buffer[0] = 0x80;
+
+        assert!(unsafe { str_from_u8_nul(&buffer) }.is_err());
+    }
+
+    #[test]
+    fn test_parse_stack() {
+        let mut stack: [u32; MAX_STACK as usize] = [0; MAX_STACK as usize];
+        stack[0] = 1;
+        stack[1] = 2;
+
+        let mut test_comm: [i8; COMM_MAXLEN as usize] = [0; COMM_MAXLEN as usize];
+        test_comm[0] = 1;
+        test_comm[1] = 2;
+        test_comm[2] = 3;
+        test_comm[3] = 4;
+
+        let ruby_stack = RubyStack {
+            timestamp: 101,
+            frames: stack,
+            pid: 5,
+            cpu: 1,
+            size: 2,
+            expected_size: 2,
+            comm: test_comm,
+            stack_status: ruby_stack_status_STACK_INCOMPLETE,
+        };
+
+        let ruby_stack_bytes = unsafe { any_as_u8_slice(&ruby_stack) };
+
+        assert_eq!(ruby_stack, unsafe { parse_stack(ruby_stack_bytes) });
+    }
+}


### PR DESCRIPTION
```
[javierhonduco@computer rbperf]$ sudo valgrind  -s target/debug/deps/rbperf-219212b34533da7c  --skip rbperf::tests::rbperf_test
==2146031== Memcheck, a memory error detector
==2146031== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==2146031== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==2146031== Command: target/debug/deps/rbperf-219212b34533da7c --skip rbperf::tests::rbperf_test
==2146031==

running 14 tests
test bindgen_test_layout_ProcessData ... ok
test binary::tests::test_malformed_ruby_version_should_panic - should panic ... ok
test binary::tests::test_ruby_current_thread_does_not_exist ... ok
test binary::tests::test_find_main_works ... ok
test bindgen_test_layout_RubyStackAddress ... ok
test bindgen_test_layout_RubyStackAddresses ... ok
test bindgen_test_layout_RubyVersionOffsets ... ok
test bindgen_test_layout_RubyStack ... ok
test bindgen_test_layout_RubyFrame ... ok
test bindgen_test_layout_SampleState ... ok
test ruby_readers::tests::test_parse_char_buffer_works ... ok
test ruby_readers::tests::test_parse_empty_char_buffer ... ok
test ruby_readers::tests::test_parse_malformed_char_buffer_errors ... ok
test ruby_readers::tests::test_parse_stack ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 9.21s

==2146031==
==2146031== HEAP SUMMARY:
==2146031==     in use at exit: 0 bytes in 0 blocks
==2146031==   total heap usage: 1,073 allocs, 1,073 frees, 60,581,564 bytes allocated
==2146031==
==2146031== All heap blocks were freed -- no leaks are possible
==2146031==
==2146031== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```