### PR TITLE
Add ringbuf as an opt-in

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,8 @@ struct RecordSubcommand {
     record_type: RecordType,
     #[clap(long)]
     verbose_bpf_logging: bool,
+    #[clap(long)]
+    ringbuf: bool,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -56,6 +58,7 @@ fn main() -> Result<()> {
             let options = RbperfOptions {
                 event,
                 verbose_bpf_logging: record.verbose_bpf_logging,
+                use_ringbuf: record.ringbuf,
             };
 
             let mut r = Rbperf::new(options);


### PR DESCRIPTION
Perf buffer is still the default. In the future, we could add automatic
feature detection for ring buffers and other features. In the meantime,
this commits gates it behind the `--ringbuf` flag

Tested with:
```
$ cargo b && sudo target/debug/rbperf record -p `pidof ruby` --ringbuf syscall enter_writev
```

and

```
$ cargo b && sudo target/debug/rbperf record -p `pidof ruby` --ringbuf syscall enter_writev
```

<img width="682" alt="image" src="https://user-images.githubusercontent.com/959128/179345632-7aa4c10e-c506-457c-8c66-21f6bbc4a01f.png">
