### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ libc = "0.2.125"
 log = "0.4.17"
 env_logger = "0.9.0"
 serde_yaml = "0.8"
+thiserror = "1.0.31"
 
 [dev-dependencies]
 nix = "0.23.1"

--- a/src/rbperf.rs
+++ b/src/rbperf.rs
@@ -169,7 +169,7 @@ impl<'a> Rbperf<'a> {
         }
     }
 
-    fn add_process_info(&mut self, process_info: ProcessInfo) -> Result<()> {
+    fn add_process_info(&mut self, process_info: &ProcessInfo) -> Result<()> {
         // Set the per-process data
         let mut matching_version: Option<(i32, &RubyVersion)> = None;
         for (i, ruby_version) in self.ruby_versions.iter().enumerate() {
@@ -215,13 +215,13 @@ impl<'a> Rbperf<'a> {
 
         Ok(())
     }
-    pub fn add_pid(&mut self, pid: Pid) -> Result<()> {
+    pub fn add_pid(&mut self, pid: Pid) -> Result<ProcessInfo> {
         // Fetch and add process info
         let process_info = ProcessInfo::new(pid)?;
         eprintln!("{}", process_info);
-        self.add_process_info(process_info)?;
+        self.add_process_info(&process_info)?;
 
-        Ok(())
+        Ok(process_info)
     }
 
     pub fn start(mut self, duration: std::time::Duration, profile: &mut Profile) -> Result<()> {


### PR DESCRIPTION
This addresses the following situations that right now were failing
with a rather confusing error message:

- Not existent syscall name
- PID that doesn't exist
- Processes that are not Ruby
- Lack of samples when sampling the CPU, as this might be due to the
  application being mostly IO bound and not running on the CPU for long.
Will revamp this and add extra logic to detect for this case in another PR

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>