### PR TITLE
syscalls tracing: Allow to trace multiple system calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "syscalls",
  "thiserror",
 ]
 
@@ -1129,6 +1130,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syscalls"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d0fbfaf55a79aacf6af721e0216f7bd12b8c1e88299cf6b7e030a6ed2e17f3"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ env_logger = "0.9.0"
 serde_yaml = "0.8"
 thiserror = "1.0.31"
 nix = "0.23.1"
+syscalls = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 project-root = "0.2.2"

--- a/build.rs
+++ b/build.rs
@@ -83,6 +83,22 @@ fn main() {
             }
         },
     }
+
+    // Turn off some clippy warnings in the generated BPF skeleton.
+    let mut contents = String::new();
+    File::open(&skel)
+        .unwrap()
+        .read_to_string(&mut contents)
+        .unwrap();
+    let new_contents = format!(
+        "#![allow(clippy::derive_partial_eq_without_eq)]\n{}",
+        contents
+    );
+    File::create(&skel)
+        .unwrap()
+        .write_all(new_contents.as_bytes())
+        .unwrap();
+
     println!("cargo:rerun-if-changed={}", HEADER);
     println!("cargo:rerun-if-changed={}", SRC);
 }

--- a/src/bpf/rbperf.h
+++ b/src/bpf/rbperf.h
@@ -44,12 +44,26 @@
 #define RUBY_T_STRING 0x05
 #define RUBY_T_ARRAY 0x07
 
+// Offset and size for the the syscall number field in x86 [1]. Would be
+// best to fetch this offset from the machine where rbperf runs, but should
+// be the same offset for all the syscalls even across architectures.
+//
+// - [1] /sys/kernel/debug/tracing/events/syscalls/*/format
+#define SYSCALL_NR_OFFSET 8
+#define SYSCALL_NR_SIZE 4
+
 u64 NATIVE_METHOD_MARKER = 0xFABADA;
 static char NATIVE_METHOD_NAME[] = "<native code>";
 
 enum ruby_stack_status {
     STACK_COMPLETE = 0,
     STACK_INCOMPLETE = 1,
+};
+
+enum rbperf_event_type {
+    RBPERF_EVENT_SYSCALL_UNKNOWN = 0,
+    RBPERF_EVENT_ON_CPU_SAMPLING = 1,
+    RBPERF_EVENT_SYSCALL = 2,
 };
 
 typedef struct {
@@ -63,6 +77,8 @@ typedef struct {
     u32 frames[MAX_STACK];
     u32 pid;
     u32 cpu;
+    // Only set when tracing syscalls.
+    int syscall_id;
     long long int size;
     long long int expected_size;
     char comm[COMM_MAXLEN];

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ struct RecordSubcommand {
 #[derive(clap::Subcommand, Debug, PartialEq)]
 enum RecordType {
     Cpu,
-    Syscall { name: String },
+    Syscall { names: Vec<String> },
 }
 
 fn main() -> Result<()> {
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
                 RecordType::Cpu => RbperfEvent::Cpu {
                     sample_period: 99999,
                 },
-                RecordType::Syscall { ref name } => RbperfEvent::Syscall(name.clone()),
+                RecordType::Syscall { ref names } => RbperfEvent::Syscall(names.clone()),
             };
             let options = RbperfOptions {
                 event,
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
                     RecordType::Cpu => {
                         return Err(anyhow!("No stacks were collected. This might mean that this process is mostly IO bound. If you believe that this might be a bug, please open an issue at https://github.com/javierhonduco/rbperf. Thanks!"));
                     }
-                    RecordType::Syscall { name: _ } => {
+                    RecordType::Syscall { names: _ } => {
                         return Err(anyhow!("No stacks were collected. Perhaps this syscall is never called. If you believe that this might be a bug, please open an issue at https://github.com/javierhonduco/rbperf. Thanks!"));
                     }
                 }

--- a/src/ruby_readers.rs
+++ b/src/ruby_readers.rs
@@ -78,6 +78,7 @@ mod tests {
             expected_size: 2,
             comm: test_comm,
             stack_status: ruby_stack_status_STACK_INCOMPLETE,
+            syscall_id: 0,
         };
 
         let ruby_stack_bytes = unsafe { any_as_u8_slice(&ruby_stack) };

--- a/tests/programs/simple_two_stacks.rb
+++ b/tests/programs/simple_two_stacks.rb
@@ -1,5 +1,8 @@
+$file_handle = nil
+
 def say_hi1
   puts 'hi'
+  $file_handle = File.open "/"
 end
 
 def e
@@ -24,6 +27,7 @@ end
 
 def say_hi2
   puts 'hi2'
+  $file_handle&.close
 end
 
 def c2


### PR DESCRIPTION
And add fake frames (see the bottom of the stack) to show which syscalls are being called

With:

```
$ cargo b --release && sudo target/release/rbperf record -p `pidof ruby-mri` syscall enter_writev enter_openat enter_close
```

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/959128/181730259-5f0a1bb6-74cc-492e-82dd-89e5b2f6e225.png">

Closes https://github.com/javierhonduco/rbperf/issues/19

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>