### PR TITLE
Improve integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
         run: |
           export RUSTFLAGS='-L /usr/lib/x86_64-linux-gnu'
           export RUST_BACKTRACE=1
-          cargo test -- --skip rbperf::tests::rbperf_test
+          cargo test -- --skip rbperf::tests
       - name: Install podman
         run: sudo apt-get -y install --no-install-recommends podman
       - name: Pull Ruby containers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,6 @@ dependencies = [
  "proc-maps",
  "project-root",
  "rand",
- "scopeguard",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ syscalls = { version = "0.6", default-features = false }
 [dev-dependencies]
 project-root = "0.2.2"
 rand = "0.8.5"
-scopeguard = "1.1.0"
 
 [build-dependencies]
 bindgen = "0.59.2"

--- a/tests/programs/cpu_hog.rb
+++ b/tests/programs/cpu_hog.rb
@@ -1,0 +1,60 @@
+def cpu
+  (0..1000).each do
+  end
+end
+
+def hog
+  (0..1000).each do
+  end
+end
+
+def program
+  (0..1000).each do
+  end
+end
+
+
+def c1
+  cpu
+end
+
+def b1
+  c1
+end
+
+def a1
+  b1
+end
+
+def c2
+  hog
+end
+
+def b2
+  c2
+end
+
+def a2
+  b2
+end
+
+def c3
+  program
+end
+
+def b3
+  c3
+end
+
+def a3
+  b3
+end
+
+$stdout.sync = true
+puts "PID: #{Process.pid}"
+
+while true
+  a1
+  a2
+  a3
+end


### PR DESCRIPTION
- by abstracting the test process functionality
- adding on-CPU profiling tests
- testing the ringbuffer
- adding a test that doesn't run the BPF code in verbose mode

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>