### PR TITLE
Handle ctrl+c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
+dependencies = [
+ "nix 0.24.2",
+ "winapi",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +921,7 @@ dependencies = [
  "bindgen",
  "chrono",
  "clap 3.2.14",
+ "ctrlc",
  "env_logger",
  "errno",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ serde_yaml = "0.8"
 thiserror = "1.0.31"
 nix = "0.23.1"
 syscalls = { version = "0.6", default-features = false }
+ctrlc = "3.2.2"
+
 
 [dev-dependencies]
 project-root = "0.2.2"


### PR DESCRIPTION
rather than exiting without writing the profile

```
[2022-08-07T20:16:43Z DEBUG rbperf::rbperf] program type Tracepoint
^C[2022-08-07T20:16:49Z DEBUG rbperf::rbperf] Polling perfbuf failed with System(4)
Got 120 samples and 0 errors
Flamegraph written to: rbperf_flame_08072022_20h16m49s.svg
```

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>