### PR TITLE
Add BPF features detection and info subcommand

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,5 +3,5 @@ BasedOnStyle: Google
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 ColumnLimit: 0
-# IndentPPDirectives: AfterHash
 IndentWidth: 4
+SortIncludes: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -37,7 +37,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -50,16 +50,17 @@ jobs:
           components: rust-src, rustfmt
       - name: Run cargo fmt
         run: |
-          # This file is generated at build time, so rustfmt will fail
-          # with Error writing files: failed to resolve mod `bpf` if it
+          # These files are generated at build time, so some rustfmt versions
+          # fail with Error writing files: failed to resolve mod `bpf` if it
           # does not exist
-          touch src/bpf/mod.rs
+          touch src/bpf/rbperf.rs
+          touch src/bpf/features.rs
           cargo fmt
           git diff --exit-code
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
@@ -83,7 +84,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-
 /target
-src/bpf/mod.rs
+src/bpf/rbperf.rs
+src/bpf/features.rs
 
 rbperf_out*
 rbperf_flame*

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ $ sudo rbperf record --pid `pidof ruby` syscall enter_writev
 
 Some debug information will be printed, and a flamegraph called `rbperf_flame_$date` will be written to disk 🎉
 
+## Developing and troubleshooting
+
+Debug logs can be enabled with `RUST_LOG=debug`. The info subcommand, `rbperf info` shows the supported BPF features as well as other supported details.
+
+
 ## Stability
 
 `rbperf` is in active development and the CLI and APIs might change any time

--- a/src/bpf/features.bpf.c
+++ b/src/bpf/features.bpf.c
@@ -1,0 +1,28 @@
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+bool feature_has_run = false;
+
+bool feature_is_jited = false;
+bool feature_has_stats = false;
+bool feature_has_tail_call = false;
+bool feature_has_ringbuf = false;
+bool feature_bpf_loop = false;
+
+SEC("kprobe/hrtimer_start_range_ns")
+int features_entry() {
+    static struct bpf_prog *bpf_prog = NULL;
+    feature_has_run = true;
+
+    feature_is_jited = bpf_core_field_exists(bpf_prog->jited);
+    feature_has_stats = bpf_core_field_exists(bpf_prog->stats);
+    feature_has_ringbuf = bpf_core_enum_value_exists(enum bpf_map_type, BPF_MAP_TYPE_RINGBUF);
+    feature_has_tail_call = bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_tail_call);
+    feature_has_ringbuf = bpf_core_enum_value_exists(enum bpf_map_type, BPF_MAP_TYPE_RINGBUF);
+    feature_bpf_loop = bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_loop);
+
+    return 0;
+}

--- a/src/bpf/mod.rs
+++ b/src/bpf/mod.rs
@@ -1,0 +1,2 @@
+pub mod features;
+pub mod rbperf;

--- a/src/bpf/rbperf.bpf.c
+++ b/src/bpf/rbperf.bpf.c
@@ -4,7 +4,6 @@
 //
 // Copyright (c) 2022 The rbperf authors
 
-// clang-format off
 #include "rbperf.h"
 
 #include "vmlinux.h"
@@ -12,7 +11,6 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
-// clang-format on
 
 struct {
     // This map's type is a placeholder, it's dynamically set

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,0 +1,53 @@
+use crate::bpf::features::FeaturesSkelBuilder;
+use anyhow::{anyhow, Result};
+use nix::sys::utsname::uname;
+use std::fs::File;
+use std::thread;
+use std::time::Duration;
+
+pub struct SystemInfo {
+    pub os_release: String,
+    pub debug_fs: bool,
+}
+
+pub struct BpfFeatures {
+    pub is_jited: bool,
+    pub has_stats: bool,
+    pub has_tail_call: bool,
+    pub has_ringbuf: bool,
+    pub has_bpf_loop: bool,
+}
+
+pub struct Info {
+    pub system: SystemInfo,
+    pub bpf: Result<BpfFeatures>,
+}
+
+pub fn info() -> Result<Info> {
+    let skel_builder = FeaturesSkelBuilder::default();
+    let open_skel = skel_builder.open().unwrap();
+    let mut bpf = open_skel.load().unwrap();
+    bpf.attach().unwrap();
+
+    thread::sleep(Duration::from_millis(50));
+
+    let bpf_features = if bpf.bss().feature_has_run {
+        Ok(BpfFeatures {
+            is_jited: bpf.bss().feature_is_jited,
+            has_stats: bpf.bss().feature_has_stats,
+            has_tail_call: bpf.bss().feature_has_tail_call,
+            has_ringbuf: bpf.bss().feature_has_ringbuf,
+            has_bpf_loop: bpf.bss().feature_bpf_loop,
+        })
+    } else {
+        Err(anyhow!("Could not find out supported BPF features"))
+    };
+
+    Ok(Info {
+        system: SystemInfo {
+            os_release: uname().release().to_string(),
+            debug_fs: File::open("/sys/kernel/debug/").is_ok(),
+        },
+        bpf: bpf_features,
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod arch;
 pub mod binary;
 pub mod bpf;
 pub mod events;
+pub mod info;
 pub mod process;
 pub mod profile;
 pub mod rbperf;

--- a/src/rbperf.rs
+++ b/src/rbperf.rs
@@ -12,7 +12,7 @@ use proc_maps::Pid;
 use syscalls;
 
 use crate::arch;
-use crate::bpf::{rbperf_rodata_types::rbperf_event_type, RbperfSkel, RbperfSkelBuilder};
+use crate::bpf::rbperf::{rbperf_rodata_types::rbperf_event_type, RbperfSkel, RbperfSkelBuilder};
 use crate::events::{setup_perf_event, setup_syscall_event};
 use crate::process::ProcessInfo;
 use crate::profile::Profile;


### PR DESCRIPTION
Right now this is most useful as a troubleshooting tool. I am planning to use this information to choose between implementations, such as whether ring buffers can be used, so `--ringbuf`doesn't have to be specified in systems that support this more efficient API

```
[javierhonduco@fedora rbperf]$ cargo run info
   Compiling rbperf v0.1.0-beta (/home/javierhonduco/code/rbperf)
    Finished dev [unoptimized + debuginfo] target(s) in 7.90s
     Running `sudo -E target/debug/rbperf info`
System info
-----------
Kernel release: 5.18.13-200.fc36.x86_64
Debugfs mounted: true

BPF features
------------
is jited: true
has stats: true
has tail_call: true
has ringbuf: true
has bpf_loop: true
```

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>