### PR TITLE
Simplify the Ruby stack walker

### DIFF
--- a/src/bpf/rbperf.h
+++ b/src/bpf/rbperf.h
@@ -52,7 +52,6 @@
 #define SYSCALL_NR_OFFSET 8
 #define SYSCALL_NR_SIZE 4
 
-u64 NATIVE_METHOD_MARKER = 0xFABADA;
 static char NATIVE_METHOD_NAME[] = "<native code>";
 
 enum ruby_stack_status {
@@ -90,7 +89,6 @@ typedef struct {
     u64 base_stack;
     u64 cfp;
     int ruby_stack_program_count;
-    long long int rb_frame_count;
     int rb_version;
 } SampleState;
 
@@ -116,12 +114,3 @@ typedef struct {
     int main_thread_offset;
     int ec_offset;
 } RubyVersionOffsets;
-
-typedef struct {
-    u64 iseq_addr;
-    u64 pc;
-} RubyStackAddress;
-
-typedef struct {
-    RubyStackAddress ruby_stack_address[MAX_STACK];
-} RubyStackAddresses;

--- a/src/rbperf.rs
+++ b/src/rbperf.rs
@@ -319,7 +319,7 @@ impl<'a> Rbperf<'a> {
 
         // Insert Ruby stack reading program
         let idx: i32 = RBPERF_STACK_READING_PROGRAM_IDX.try_into().unwrap();
-        let val = self.bpf.obj.prog("read_ruby_stack").unwrap().fd();
+        let val = self.bpf.obj.prog("walk_ruby_stack").unwrap().fd();
 
         let mut maps = self.bpf.maps_mut();
         let programs = maps.programs();


### PR DESCRIPTION
The overly complicated stack walking in two steps was implemented to try to pack as much work as possible per loop iteration to prevent the BPF verifier from rejecting our program due to the high complexity while analysing all the potential code paths, but I don't think this is needed anymore, so removing it to make the code vastly simpler!

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>