### PR TITLE
Use explicit container registry for ruby image.

### DIFF
--- a/tests/programs/Dockerfile.server
+++ b/tests/programs/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM ruby:3.0.0
+FROM docker.io/ruby:3.0.0
 
 WORKDIR /code
 COPY server.rb /code


### PR DESCRIPTION
This fixes the provided instructions for systems
that don't automatically prefix with docker.io.
