### PR TITLE
Add line number tracking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@1.64.0
         with:
           components: rust-src, clippy, rustfmt
       - name: Install build system dependencies

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,8 @@ struct RecordSubcommand {
     ringbuf: bool,
     #[clap(long)]
     disable_pid_race_detector: bool,
+    #[clap(long)]
+    enable_linenos: bool,
 }
 
 #[derive(clap::Subcommand, Debug, PartialEq)]
@@ -145,6 +147,7 @@ fn main() -> Result<()> {
                 use_ringbuf: record.ringbuf,
                 verbose_libbpf_logging: record.verbose_libbpf_logging,
                 disable_pid_race_detector: record.disable_pid_race_detector,
+                enable_linenos: record.enable_linenos,
             };
 
             let mut r = Rbperf::new(options);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -105,6 +105,14 @@ fn dump_ruby_structs_ruby_2_6_3() {
     let main_thread_offset: i32 =
         offset_of!(rbspy_ruby_structs::ruby_2_6_3::rb_vm_struct, main_thread) as i32;
 
+    assert!(
+        offset_of!(
+            rbspy_ruby_structs::ruby_2_6_3::rb_iseq_constant_body,
+            iseq_encoded
+        ) as i32
+            == 0x8
+    );
+
     let ruby_2_6_0_offsets = RubyVersionOffsets {
         major_version: 2,
         minor_version: 6,
@@ -167,6 +175,14 @@ fn dump_ruby_structs_ruby_2_7_1() {
 
     let main_thread_offset: i32 =
         offset_of!(rbspy_ruby_structs::ruby_2_7_1::rb_vm_struct, main_thread) as i32;
+
+    assert!(
+        offset_of!(
+            rbspy_ruby_structs::ruby_2_7_1::rb_iseq_constant_body,
+            iseq_encoded
+        ) as i32
+            == 0x8
+    );
 
     let ruby_2_7_1_offsets = RubyVersionOffsets {
         major_version: 2,
@@ -231,6 +247,14 @@ fn dump_ruby_structs_ruby_2_7_4() {
     let main_thread_offset: i32 =
         offset_of!(rbspy_ruby_structs::ruby_2_7_4::rb_vm_struct, main_thread) as i32;
 
+    assert!(
+        offset_of!(
+            rbspy_ruby_structs::ruby_2_7_4::rb_iseq_constant_body,
+            iseq_encoded
+        ) as i32
+            == 0x8
+    );
+
     let ruby_2_7_4_offsets = RubyVersionOffsets {
         major_version: 2,
         minor_version: 7,
@@ -293,6 +317,14 @@ fn dump_ruby_structs_ruby_2_7_6() {
 
     let main_thread_offset: i32 =
         offset_of!(rbspy_ruby_structs::ruby_2_7_6::rb_vm_struct, main_thread) as i32;
+
+    assert!(
+        offset_of!(
+            rbspy_ruby_structs::ruby_2_7_6::rb_iseq_constant_body,
+            iseq_encoded
+        ) as i32
+            == 0x8
+    );
 
     let ruby_2_7_6_offsets = RubyVersionOffsets {
         major_version: 2,
@@ -357,6 +389,14 @@ fn dump_ruby_structs_ruby_3_0_0() {
         rbspy_ruby_structs::ruby_3_0_0::rb_vm_struct__bindgen_ty_1,
         main_thread
     ) as i32;
+
+    assert!(
+        offset_of!(
+            rbspy_ruby_structs::ruby_3_0_0::rb_iseq_constant_body,
+            iseq_encoded
+        ) as i32
+            == 0x8
+    );
 
     let ruby_3_0_0_offsets = RubyVersionOffsets {
         major_version: 3,
@@ -434,6 +474,14 @@ fn dump_ruby_structs_ruby_3_0_4() {
         main_thread
     ) as i32;
 
+    assert!(
+        offset_of!(
+            rbspy_ruby_structs::ruby_3_0_4::rb_iseq_constant_body,
+            iseq_encoded
+        ) as i32
+            == 0x8
+    );
+
     let ruby_3_0_4_offsets = RubyVersionOffsets {
         major_version: 3,
         minor_version: 0,
@@ -509,6 +557,14 @@ fn dump_ruby_structs_ruby_3_1_2() {
         rbspy_ruby_structs::ruby_3_1_2::rb_vm_struct__bindgen_ty_1,
         main_thread
     ) as i32;
+
+    assert!(
+        offset_of!(
+            rbspy_ruby_structs::ruby_3_1_2::rb_iseq_constant_body,
+            iseq_encoded
+        ) as i32
+            == 0x8
+    );
 
     let ruby_3_1_2_offsets = RubyVersionOffsets {
         major_version: 3,


### PR DESCRIPTION
This is disabled by default as it's not fully implemented and the numbers might not be totally accurate unfortunately. Can be enabled with `--enable-linenos`

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>